### PR TITLE
fix: use ceiling division for veto threshold to prevent rounding to zero

### DIFF
--- a/contracts/governance/ReserveOptimisticGovernor.sol
+++ b/contracts/governance/ReserveOptimisticGovernor.sol
@@ -244,7 +244,10 @@ contract ReserveOptimisticGovernor is
             }
 
             // {tok} = D18{1} * {tok} / D18{1}
-            uint256 vetoThresholdTok = (_vetoThreshold * token().getPastTotalSupply(snapshot)) / 1e18;
+            // Use ceiling division so a nonzero _vetoThreshold always produces
+            // a nonzero token threshold (minimum 1 wei).
+            uint256 product = _vetoThreshold * token().getPastTotalSupply(snapshot);
+            uint256 vetoThresholdTok = (product + 1e18 - 1) / 1e18;
 
             if (vetoThresholdTok == 0) {
                 return ProposalState.Canceled;


### PR DESCRIPTION
## Summary

- Replaces floor division with ceiling division in veto threshold calculation
- Prevents `vetoThresholdTok` from rounding to zero and unconditionally canceling proposals

## Problem

At line 247 of `ReserveOptimisticGovernor.sol`:

```solidity
uint256 vetoThresholdTok = (_vetoThreshold * token().getPastTotalSupply(snapshot)) / 1e18;
```

Floor division can produce 0 when `_vetoThreshold * totalSupply < 1e18`. Line 249 then cancels the proposal unconditionally when `vetoThresholdTok == 0`. With ceiling division, a nonzero `_vetoThreshold` always produces at least 1 wei of token threshold.

Fixes #24

## Test plan

- [ ] Proposals with normal parameters behave identically (ceiling vs floor produces same result for large totalSupply)
- [ ] Edge case: very small `_vetoThreshold` with small `totalSupply` no longer auto-cancels