### PR TITLE
align optimistic governor interface with live ABI

### DIFF
--- a/contracts/governance/ReserveOptimisticGovernor.sol
+++ b/contracts/governance/ReserveOptimisticGovernor.sol
@@ -28,10 +28,10 @@ import {
 } from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
+import { IOptimisticSelectorRegistry } from "@interfaces/IOptimisticSelectorRegistry.sol";
 import { IOptimisticVotes } from "@interfaces/IOptimisticVotes.sol";
 import { IReserveOptimisticGovernor } from "@interfaces/IReserveOptimisticGovernor.sol";
 
-import { OptimisticSelectorRegistry } from "@governance/OptimisticSelectorRegistry.sol";
 import { TimelockControllerOptimistic } from "@governance/TimelockControllerOptimistic.sol";
 import { ProposalLib } from "@governance/lib/ProposalLib.sol";
 import { ThrottleLib } from "@governance/lib/ThrottleLib.sol";
@@ -64,16 +64,15 @@ contract ReserveOptimisticGovernor is
     GovernorVotesQuorumFractionUpgradeable,
     GovernorTimelockControlUpgradeable,
     Versioned,
-    UUPSUpgradeable,
-    IReserveOptimisticGovernor
+    UUPSUpgradeable
 {
-    OptimisticGovernanceParams public optimisticParams;
+    IReserveOptimisticGovernor.OptimisticGovernanceParams public optimisticParams;
 
-    OptimisticSelectorRegistry public selectorRegistry;
+    IOptimisticSelectorRegistry public selectorRegistry;
 
     ThrottleLib.ProposalThrottleStorage private proposalThrottle;
 
-    mapping(uint256 proposalId => OptimisticProposalDetails) private optimisticProposalDetails;
+    mapping(uint256 proposalId => IReserveOptimisticGovernor.OptimisticProposalDetails) private optimisticProposalDetails;
 
     constructor() {
         _disableInitializers();
@@ -89,8 +88,8 @@ contract ReserveOptimisticGovernor is
     /// @param standardGovParams.quorumNumerator D18{1} Fraction of token supply required to reach quorum
     /// @param _proposalThrottleCapacity Optimistic proposals-per-account per 24h
     function initialize(
-        OptimisticGovernanceParams calldata optimisticGovParams,
-        StandardGovernanceParams calldata standardGovParams,
+        IReserveOptimisticGovernor.OptimisticGovernanceParams calldata optimisticGovParams,
+        IReserveOptimisticGovernor.StandardGovernanceParams calldata standardGovParams,
         uint256 _proposalThrottleCapacity,
         address _token,
         address _timelockController,
@@ -110,14 +109,17 @@ contract ReserveOptimisticGovernor is
         _setProposalThrottle(_proposalThrottleCapacity);
         _setOptimisticParams(optimisticGovParams);
 
-        selectorRegistry = OptimisticSelectorRegistry(payable(_selectorRegistry));
+        selectorRegistry = IOptimisticSelectorRegistry(_selectorRegistry);
     }
 
     function setProposalThrottle(uint256 newProposalThrottleCapacity) external onlyGovernance {
         _setProposalThrottle(newProposalThrottleCapacity);
     }
 
-    function setOptimisticParams(OptimisticGovernanceParams calldata params) external onlyGovernance {
+    function setOptimisticParams(IReserveOptimisticGovernor.OptimisticGovernanceParams calldata params)
+        external
+        onlyGovernance
+    {
         _setOptimisticParams(params);
     }
 
@@ -158,7 +160,7 @@ contract ReserveOptimisticGovernor is
 
         proposalId = getProposalId(targets, values, calldatas, keccak256(bytes(description)));
 
-        optimisticProposalDetails[proposalId] = OptimisticProposalDetails({
+        optimisticProposalDetails[proposalId] = IReserveOptimisticGovernor.OptimisticProposalDetails({
             targets: targets,
             values: values,
             calldatas: calldatas,
@@ -193,7 +195,7 @@ contract ReserveOptimisticGovernor is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) public override(GovernorUpgradeable, IReserveOptimisticGovernor) returns (uint256 proposalId) {
+    ) public override(GovernorUpgradeable) returns (uint256 proposalId) {
         return super.cancel(targets, values, calldatas, descriptionHash);
     }
 
@@ -317,7 +319,7 @@ contract ReserveOptimisticGovernor is
     function timelock()
         public
         view
-        override(GovernorTimelockControlUpgradeable, IReserveOptimisticGovernor)
+        override(GovernorTimelockControlUpgradeable)
         returns (address)
     {
         return super.timelock();
@@ -332,7 +334,10 @@ contract ReserveOptimisticGovernor is
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) internal override(GovernorUpgradeable, GovernorTimelockControlUpgradeable) returns (uint48) {
-        require(!_isOptimistic(proposalId), OptimisticGovernor__OptimisticProposalCannotBeQueued(proposalId));
+        require(
+            !_isOptimistic(proposalId),
+            IReserveOptimisticGovernor.OptimisticGovernor__OptimisticProposalCannotBeQueued(proposalId)
+        );
 
         return super._queueOperations(proposalId, targets, values, calldatas, descriptionHash);
     }
@@ -389,7 +394,7 @@ contract ReserveOptimisticGovernor is
     {
         require(
             !_isOptimistic(proposalId) || support == uint8(VoteType.Against),
-            OptimisticGovernor__OptimisticProposalCanOnlyBeVetoed(proposalId)
+            IReserveOptimisticGovernor.OptimisticGovernor__OptimisticProposalCanOnlyBeVetoed(proposalId)
         );
 
         return super._countVote(proposalId, account, support, totalWeight, params);
@@ -429,7 +434,7 @@ contract ReserveOptimisticGovernor is
             return super._tallyUpdated(proposalId);
         }
 
-        OptimisticProposalDetails storage optimisticProposal = optimisticProposalDetails[proposalId];
+        IReserveOptimisticGovernor.OptimisticProposalDetails storage optimisticProposal = optimisticProposalDetails[proposalId];
 
         if (state(proposalId) == ProposalState.Defeated) {
             // transition optimistic -> pessimistic
@@ -454,7 +459,8 @@ contract ReserveOptimisticGovernor is
 
     function _setProposalThreshold(uint256 newProposalThreshold) internal override {
         require(
-            newProposalThreshold != 0 && newProposalThreshold <= 1e18, OptimisticGovernor__InvalidProposalThreshold()
+            newProposalThreshold != 0 && newProposalThreshold <= 1e18,
+            IReserveOptimisticGovernor.OptimisticGovernor__InvalidProposalThreshold()
         );
 
         super._setProposalThreshold(newProposalThreshold);
@@ -464,34 +470,36 @@ contract ReserveOptimisticGovernor is
     function _setProposalThrottle(uint256 newCapacity) internal {
         require(
             newCapacity != 0 && newCapacity <= MAX_PROPOSAL_THROTTLE_CAPACITY,
-            OptimisticGovernor__InvalidProposalThrottle()
+            IReserveOptimisticGovernor.OptimisticGovernor__InvalidProposalThrottle()
         );
 
         proposalThrottle.capacity = newCapacity;
-        emit ProposalThrottleUpdated(newCapacity);
+        emit IReserveOptimisticGovernor.ProposalThrottleUpdated(newCapacity);
     }
 
     function _setVotingDelay(uint48 newVotingDelay) internal override {
-        require(newVotingDelay < MAX_OPTIMISTIC_DELAY, OptimisticGovernor__InvalidDelay());
+        require(newVotingDelay < MAX_OPTIMISTIC_DELAY, IReserveOptimisticGovernor.OptimisticGovernor__InvalidDelay());
 
         super._setVotingDelay(newVotingDelay);
     }
 
     function _setLateQuorumVoteExtension(uint48 newVoteExtension) internal override {
-        require(newVoteExtension < MAX_VOTE_EXTENSION, OptimisticGovernor__InvalidDelay());
+        require(
+            newVoteExtension < MAX_VOTE_EXTENSION, IReserveOptimisticGovernor.OptimisticGovernor__InvalidDelay()
+        );
 
         super._setLateQuorumVoteExtension(newVoteExtension);
     }
 
-    function _setOptimisticParams(OptimisticGovernanceParams calldata params) private {
+    function _setOptimisticParams(IReserveOptimisticGovernor.OptimisticGovernanceParams calldata params) private {
         require(
             params.vetoDelay >= MIN_OPTIMISTIC_VETO_DELAY && params.vetoDelay < MAX_OPTIMISTIC_DELAY
                 && params.vetoPeriod >= MIN_OPTIMISTIC_VETO_PERIOD && params.vetoThreshold != 0
                 && params.vetoThreshold <= 1e18,
-            OptimisticGovernor__InvalidOptimisticParameters()
+            IReserveOptimisticGovernor.OptimisticGovernor__InvalidOptimisticParameters()
         );
         optimisticParams = params;
-        emit OptimisticParamsUpdated(params);
+        emit IReserveOptimisticGovernor.OptimisticParamsUpdated(params);
     }
 
     // === Private ===

--- a/contracts/governance/lib/ProposalLib.sol
+++ b/contracts/governance/lib/ProposalLib.sol
@@ -8,9 +8,9 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { GovernorUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/GovernorUpgradeable.sol";
 
+import { IOptimisticSelectorRegistry } from "@interfaces/IOptimisticSelectorRegistry.sol";
 import { IReserveOptimisticGovernor } from "@interfaces/IReserveOptimisticGovernor.sol";
 
-import { OptimisticSelectorRegistry } from "@governance/OptimisticSelectorRegistry.sol";
 import { ReserveOptimisticGovernor } from "@governance/ReserveOptimisticGovernor.sol";
 import { OPTIMISTIC_PROPOSER_ROLE } from "@utils/Constants.sol";
 
@@ -49,7 +49,7 @@ library ProposalLib {
         // validate calls
 
         {
-            OptimisticSelectorRegistry selectorRegistry = governor.selectorRegistry();
+            IOptimisticSelectorRegistry selectorRegistry = governor.selectorRegistry();
 
             for (uint256 i = 0; i < proposal.targets.length; i++) {
                 address target = proposal.targets[i];

--- a/contracts/interfaces/IReserveOptimisticGovernor.sol
+++ b/contracts/interfaces/IReserveOptimisticGovernor.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-interface IReserveOptimisticGovernor {
+import { IERC5805 } from "@openzeppelin/contracts/interfaces/IERC5805.sol";
+import { IGovernor } from "@openzeppelin/contracts/governance/IGovernor.sol";
+
+import { IOptimisticSelectorRegistry } from "./IOptimisticSelectorRegistry.sol";
+
+interface IReserveOptimisticGovernor is IGovernor {
     // === Errors ===
 
     error OptimisticGovernor__InvalidProposalThreshold();
@@ -55,11 +60,63 @@ interface IReserveOptimisticGovernor {
         address _selectorRegistry
     ) external;
 
+    function lateQuorumVoteExtension() external view returns (uint48);
+
+    function optimisticParams() external view returns (uint48 vetoDelay, uint32 vetoPeriod, uint256 vetoThreshold);
+
+    function proposalThrottleCapacity() external view returns (uint256);
+
+    function proposalThrottleCharges(address account) external view returns (uint256);
+
+    function proposalVotes(uint256 proposalId)
+        external
+        view
+        returns (uint256 againstVotes, uint256 forVotes, uint256 abstainVotes);
+
+    function proposeOptimistic(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata calldatas,
+        string calldata description
+    ) external returns (uint256 proposalId);
+
+    function quorumDenominator() external pure returns (uint256);
+
+    function quorumNumerator() external view returns (uint256);
+
+    function quorumNumerator(uint256 timepoint) external view returns (uint256);
+
+    function relay(address target, uint256 value, bytes calldata data) external payable;
+
+    function selectorRegistry() external view returns (IOptimisticSelectorRegistry);
+
+    function setLateQuorumVoteExtension(uint48 newVoteExtension) external;
+
+    function setOptimisticParams(OptimisticGovernanceParams calldata params) external;
+
+    function setProposalThreshold(uint256 newProposalThreshold) external;
+
+    function setProposalThrottle(uint256 newProposalThrottleCapacity) external;
+
+    function setVotingDelay(uint48 newVotingDelay) external;
+
+    function setVotingPeriod(uint32 newVotingPeriod) external;
+
+    function token() external view returns (IERC5805);
+
+    function updateQuorumNumerator(uint256 newQuorumNumerator) external;
+
+    function updateTimelock(address newTimelock) external;
+
+    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable;
+
     function getOptimisticVotes(address account, uint256 timepoint) external view returns (uint256);
 
     function isOptimistic(uint256 proposalId) external view returns (bool);
 
     function timelock() external view returns (address);
+
+    function vetoThreshold(uint256 proposalId) external view returns (uint256);
 
     function cancel(
         address[] calldata targets,

--- a/test/ReserveOptimisticGovernor.t.sol
+++ b/test/ReserveOptimisticGovernor.t.sol
@@ -224,6 +224,58 @@ abstract contract ReserveOptimisticGovernorTestBase is Test {
         }
     }
 
+    function test_interface_exposesLegacyAndOptimisticGovernanceSurface() public view {
+        IReserveOptimisticGovernor governorInterface = IReserveOptimisticGovernor(address(governor));
+
+        assertEq(address(governorInterface.selectorRegistry()), address(registry));
+        assertEq(governorInterface.proposalThrottleCapacity(), PROPOSAL_THROTTLE_CAPACITY);
+        assertEq(governorInterface.proposalThrottleCharges(optimisticProposer), PROPOSAL_THROTTLE_CAPACITY);
+        assertEq(address(governorInterface.token()), address(stakingVault));
+        assertEq(governorInterface.votingDelay(), VOTING_DELAY);
+        assertEq(governorInterface.votingPeriod(), VOTING_PERIOD);
+        assertEq(governorInterface.proposalThreshold(), governor.proposalThreshold());
+
+        (uint256 againstVotes, uint256 forVotes, uint256 abstainVotes) = governorInterface.proposalVotes(0);
+        assertEq(againstVotes, 0);
+        assertEq(forVotes, 0);
+        assertEq(abstainVotes, 0);
+
+        (uint48 vetoDelay, uint32 vetoPeriod, uint256 vetoThreshold) = governorInterface.optimisticParams();
+        assertEq(vetoDelay, VETO_DELAY);
+        assertEq(vetoPeriod, VETO_PERIOD);
+        assertEq(vetoThreshold, VETO_THRESHOLD);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(underlying);
+
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeCall(IERC20.transfer, (alice, 1));
+
+        IReserveOptimisticGovernor.OptimisticGovernanceParams memory optimisticParams =
+            IReserveOptimisticGovernor.OptimisticGovernanceParams({ vetoDelay: 1, vetoPeriod: 1, vetoThreshold: 1 });
+
+        bytes memory payload = abi.encodeCall(IGovernor.propose, (targets, values, calldatas, "std"));
+        payload = abi.encodeCall(IGovernor.queue, (targets, values, calldatas, bytes32(0)));
+        payload = abi.encodeCall(IGovernor.execute, (targets, values, calldatas, bytes32(0)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.cancel, (targets, values, calldatas, bytes32(0)));
+        payload = abi.encodeCall(IGovernor.castVote, (uint256(0), uint8(0)));
+        payload = abi.encodeCall(IGovernor.castVoteWithReasonAndParams, (uint256(0), uint8(0), "", bytes("")));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.proposeOptimistic, (targets, values, calldatas, "opt"));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.setVotingDelay, (uint48(1)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.setVotingPeriod, (uint32(1)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.setLateQuorumVoteExtension, (uint48(1)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.setProposalThreshold, (uint256(1)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.setProposalThrottle, (uint256(1)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.setOptimisticParams, (optimisticParams));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.updateQuorumNumerator, (uint256(1)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.updateTimelock, (address(timelock)));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.upgradeToAndCall, (address(governor), bytes("")));
+        payload = abi.encodeCall(IReserveOptimisticGovernor.relay, (address(underlying), uint256(0), bytes("")));
+
+        assertGt(payload.length, 0);
+    }
+
     function _additionalGuardians() internal view returns (address[] memory guardians) {
         guardians = new address[](1);
         guardians[0] = additionalGuardian;


### PR DESCRIPTION
## Summary
- expand `IReserveOptimisticGovernor` so integrations can keep using the existing OZ governor command surface while picking up the optimistic governor additions
- switch selector-registry references to the interface type and keep the concrete governor implementation aligned with the external ABI without changing behavior
- add an interface-surface test that locks in the legacy governance commands plus the new optimistic methods as a superset

## Testing
- `forge build`
- `forge test --match-path test/ReserveOptimisticGovernor.t.sol`