### PR TITLE
Configure dependency install policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+
 patchedDependencies:
   "@openzeppelin/contracts-upgradeable": patches/@openzeppelin__contracts-upgradeable.patch


### PR DESCRIPTION
## Summary
- Set pnpm minimumReleaseAge to 10080 minutes (7 days)
- Enable pnpm blockExoticSubdeps

## Verification
- pnpm config get minimumReleaseAge -> 10080
- pnpm config get blockExoticSubdeps -> true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to enhance dependency management and stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reserve-protocol/reserve-governor/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->